### PR TITLE
ci: add tag of short-sha to docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,9 @@ name: Create and publish a Docker image
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
+      - docker-tags
     paths:
       - "src/**"
       - "patches/**"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,7 @@ name: Create and publish a Docker image
 
 on:
   push:
-    branches:
-      - main
-      - docker-tags
+    branches: ["main"]
     paths:
       - "src/**"
       - "patches/**"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,9 +42,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.normalize-repository-name.outputs.repository }}
+          tags: |
+            type=raw,value=latest
+            type=sha,format=short
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ steps.normalize-repository-name.outputs.repository }}:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
With this project, it is highly recommended to review the code I'm running.

For that, I want to be able to run a specific version of the project, and not automaticlly receive the latest version, which, in case of bad thing happend, will stole my passwords.

With this change, each docker image will be tagged with the git commit hash, and we will be able to consume it even if the latest is another image.
