### PR TITLE
chore(deps): bump @actual-app/api to ^26.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@actual-app/api": "^26.5.0",
+        "@actual-app/api": "^26.6.0",
         "@mswjs/interceptors": "^0.41.8",
         "@telegraf/entity": "^0.7.0",
         "async": "^3.2.6",
@@ -54,24 +54,38 @@
       }
     },
     "node_modules/@actual-app/api": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.5.0.tgz",
-      "integrity": "sha512-KnNlHsccQxsRPB+bDVCc9tTLM8m7p2an1hN0b7Eb8o2ZnLAx0sVIedBy0pwpxCONVlg12L98ULkRcQ/e04Fq3Q==",
+      "version": "26.6.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.6.0.tgz",
+      "integrity": "sha512-nDmBGyhEmJpb2SRXxGN+LrNMAJMTMOkbOtk3GG7QKWc2EiqMEbsTiYtxcHyU1X+HV7jxnez6mQW4c7srPf61fA==",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/core": "26.5.0",
-        "@actual-app/crdt": "2.1.0",
+        "@actual-app/core": "26.6.0",
+        "@actual-app/crdt": "3.0.0",
         "better-sqlite3": "^12.8.0",
-        "compare-versions": "^6.1.1"
+        "compare-versions": "^6.1.1",
+        "uuid": "^14.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
+    "node_modules/@actual-app/api/node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/@actual-app/core": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.5.0.tgz",
-      "integrity": "sha512-JSpMOYDw8LQLkdKWkZlC6KpetFhuo0pggDvExfwhDe6NL3GmKiPw8LseW4+M3w7rS8Gvs8xKmqI9cWqWNUIV0Q==",
+      "version": "26.6.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.6.0.tgz",
+      "integrity": "sha512-qrlsds+DpYxrjfQa5BEPOw9eOxQFt6z4zDLo2tt+veBHIwVnD1ewjsycIOxs57Nl+o872SXvsf1XNamoz9Lhdg==",
       "license": "ISC",
       "dependencies": {
         "@jlongster/sql.js": "^1.6.7",
@@ -83,7 +97,6 @@
         "csv-parse": "^6.2.1",
         "csv-stringify": "^6.7.0",
         "date-fns": "^4.1.0",
-        "google-protobuf": "^3.21.4",
         "handlebars": "^4.7.9",
         "hyperformula": "^3.2.0",
         "lodash": "^4.18.1",
@@ -93,29 +106,45 @@
         "promise-retry": "^2.0.1",
         "typescript-strict-plugin": "^2.4.4",
         "ua-parser-js": "^2.0.9",
+        "uuid": "^14.0.0",
         "xml2js": "^0.6.2"
       }
     },
-    "node_modules/@actual-app/crdt": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@actual-app/crdt/-/crdt-2.1.0.tgz",
-      "integrity": "sha512-Qb8hMq10Wi2kYIDj0fG4uy00f9Mloghd+xQrHQiPQfgx022VPJ/No+z/bmfj4MuFH8FrPiLysSzRsj2PNQIedw==",
-      "dependencies": {
-        "google-protobuf": "^3.12.0-rc.1",
-        "murmurhash": "^2.0.1",
-        "uuid": "^9.0.0"
-      }
-    },
-    "node_modules/@actual-app/crdt/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+    "node_modules/@actual-app/core/node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/@actual-app/crdt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/crdt/-/crdt-3.0.0.tgz",
+      "integrity": "sha512-qTdqAa5rPGBLDld932ox4ADRLpX+SDXIyuJpdP0GIimH6ekYX375bwLrWznev2B8aIZVU+R83I6+ltV2lQOpvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.11.0",
+        "murmurhash": "^2.0.1",
+        "uuid": "^14.0.0"
+      }
+    },
+    "node_modules/@actual-app/crdt/node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -959,6 +988,12 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.0",
@@ -2267,9 +2302,9 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
@@ -2664,9 +2699,9 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
-      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2674,7 +2709,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bignumber.js": {
@@ -3252,9 +3287,9 @@
       "license": "MIT"
     },
     "node_modules/csv-stringify": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.7.0.tgz",
-      "integrity": "sha512-UdtziYp5HuTz7e5j8Nvq+a/3HQo+2/aJZ9xntNTpmRRIg/3YYqDVgiS9fvAhtNbnyfbv2ZBe0bqCHqzhE7FqWQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.0.tgz",
+      "integrity": "sha512-Ya0OOHb6XbgPaZKH7dcdmwXe3azUS0TwmlbVdS75HoAhnHApSkiQcfEJoC/s5WwGsrXwOjBDr3FTmCZPjkssgg==",
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
@@ -4267,11 +4302,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/google-protobuf": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
-      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ=="
-    },
     "node_modules/google-spreadsheet": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/google-spreadsheet/-/google-spreadsheet-5.2.0.tgz",
@@ -4435,9 +4465,9 @@
       }
     },
     "node_modules/hyperformula": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.2.0.tgz",
-      "integrity": "sha512-2vzQKKVMDPLsubZJb0JJWT/DhrkgIjsWj40Z9BIUVT6Jkl/YM5VtkLOP3agCieqW9HuqnXlWc+Vi+7XzQuC1Nw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.3.0.tgz",
+      "integrity": "sha512-Mkc7AxP9WQDM4xHo1/XpAwzcpMLkwMand4HO9rfRzP502TBzoR1Z96zoCzRrwXodLSVyh+MD7FvzRVALDxmRFQ==",
       "license": "GPL-3.0-only",
       "dependencies": {
         "chevrotain": "^6.5.0",
@@ -6070,7 +6100,8 @@
     "node_modules/murmurhash": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/murmurhash/-/murmurhash-2.0.1.tgz",
-      "integrity": "sha512-5vQEh3y+DG/lMPM0mCGPDnyV8chYg/g7rl6v3Gd8WMF9S429ox3Xk8qrk174kWhG767KQMqqxLD1WnGd77hiew=="
+      "integrity": "sha512-5vQEh3y+DG/lMPM0mCGPDnyV8chYg/g7rl6v3Gd8WMF9S429ox3Xk8qrk174kWhG767KQMqqxLD1WnGd77hiew==",
+      "license": "MIT"
     },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
@@ -6136,9 +6167,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "version": "3.93.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.93.0.tgz",
+      "integrity": "sha512-Cu6yUpX5Iavugm8BeX7c0wgU9CvOqfd1yM6A1d2q2ZMjym7GjpASv2GdRcTq3Fx+Sb5OgBkEEpw4VnAbY6Y5RA==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -6148,9 +6179,9 @@
       }
     },
     "node_modules/node-abi/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6899,9 +6930,9 @@
       }
     },
     "node_modules/prebuild-install/node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -8053,9 +8084,9 @@
       }
     },
     "node_modules/typescript-strict-plugin/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -8148,9 +8179,9 @@
       }
     },
     "node_modules/typescript-strict-plugin/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^7.0.2",
@@ -8195,9 +8226,9 @@
       "license": "MIT"
     },
     "node_modules/ua-parser-js": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.9.tgz",
-      "integrity": "sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.10.tgz",
+      "integrity": "sha512-t+3Ktbq0Ies2vaSezfOaWiolH4OigQIO1dk+1xDpOydB1COVPocVYOrEV5rqZ0kFY9XYG1v9LutCyMgYBpABcw==",
       "funding": [
         {
           "type": "opencollective",
@@ -8612,20 +8643,28 @@
   },
   "dependencies": {
     "@actual-app/api": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.5.0.tgz",
-      "integrity": "sha512-KnNlHsccQxsRPB+bDVCc9tTLM8m7p2an1hN0b7Eb8o2ZnLAx0sVIedBy0pwpxCONVlg12L98ULkRcQ/e04Fq3Q==",
+      "version": "26.6.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.6.0.tgz",
+      "integrity": "sha512-nDmBGyhEmJpb2SRXxGN+LrNMAJMTMOkbOtk3GG7QKWc2EiqMEbsTiYtxcHyU1X+HV7jxnez6mQW4c7srPf61fA==",
       "requires": {
-        "@actual-app/core": "26.5.0",
-        "@actual-app/crdt": "2.1.0",
+        "@actual-app/core": "26.6.0",
+        "@actual-app/crdt": "3.0.0",
         "better-sqlite3": "^12.8.0",
-        "compare-versions": "^6.1.1"
+        "compare-versions": "^6.1.1",
+        "uuid": "^14.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "14.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+          "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="
+        }
       }
     },
     "@actual-app/core": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.5.0.tgz",
-      "integrity": "sha512-JSpMOYDw8LQLkdKWkZlC6KpetFhuo0pggDvExfwhDe6NL3GmKiPw8LseW4+M3w7rS8Gvs8xKmqI9cWqWNUIV0Q==",
+      "version": "26.6.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.6.0.tgz",
+      "integrity": "sha512-qrlsds+DpYxrjfQa5BEPOw9eOxQFt6z4zDLo2tt+veBHIwVnD1ewjsycIOxs57Nl+o872SXvsf1XNamoz9Lhdg==",
       "requires": {
         "@jlongster/sql.js": "^1.6.7",
         "@rschedule/core": "^1.5.0",
@@ -8636,7 +8675,6 @@
         "csv-parse": "^6.2.1",
         "csv-stringify": "^6.7.0",
         "date-fns": "^4.1.0",
-        "google-protobuf": "^3.21.4",
         "handlebars": "^4.7.9",
         "hyperformula": "^3.2.0",
         "lodash": "^4.18.1",
@@ -8646,23 +8684,31 @@
         "promise-retry": "^2.0.1",
         "typescript-strict-plugin": "^2.4.4",
         "ua-parser-js": "^2.0.9",
+        "uuid": "^14.0.0",
         "xml2js": "^0.6.2"
-      }
-    },
-    "@actual-app/crdt": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@actual-app/crdt/-/crdt-2.1.0.tgz",
-      "integrity": "sha512-Qb8hMq10Wi2kYIDj0fG4uy00f9Mloghd+xQrHQiPQfgx022VPJ/No+z/bmfj4MuFH8FrPiLysSzRsj2PNQIedw==",
-      "requires": {
-        "google-protobuf": "^3.12.0-rc.1",
-        "murmurhash": "^2.0.1",
-        "uuid": "^9.0.0"
       },
       "dependencies": {
         "uuid": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+          "version": "14.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+          "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="
+        }
+      }
+    },
+    "@actual-app/crdt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/crdt/-/crdt-3.0.0.tgz",
+      "integrity": "sha512-qTdqAa5rPGBLDld932ox4ADRLpX+SDXIyuJpdP0GIimH6ekYX375bwLrWznev2B8aIZVU+R83I6+ltV2lQOpvg==",
+      "requires": {
+        "@bufbuild/protobuf": "^2.11.0",
+        "murmurhash": "^2.0.1",
+        "uuid": "^14.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "14.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+          "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="
         }
       }
     },
@@ -9297,6 +9343,11 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@bufbuild/protobuf": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg=="
     },
     "@emnapi/core": {
       "version": "1.9.0",
@@ -10295,9 +10346,9 @@
       }
     },
     "adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng=="
     },
     "agent-base": {
       "version": "7.1.3",
@@ -10567,9 +10618,9 @@
       "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="
     },
     "better-sqlite3": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
-      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "requires": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -10973,9 +11024,9 @@
       "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ=="
     },
     "csv-stringify": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.7.0.tgz",
-      "integrity": "sha512-UdtziYp5HuTz7e5j8Nvq+a/3HQo+2/aJZ9xntNTpmRRIg/3YYqDVgiS9fvAhtNbnyfbv2ZBe0bqCHqzhE7FqWQ=="
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.0.tgz",
+      "integrity": "sha512-Ya0OOHb6XbgPaZKH7dcdmwXe3azUS0TwmlbVdS75HoAhnHApSkiQcfEJoC/s5WwGsrXwOjBDr3FTmCZPjkssgg=="
     },
     "data-uri-to-buffer": {
       "version": "6.0.2",
@@ -11653,11 +11704,6 @@
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
       "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="
     },
-    "google-protobuf": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
-      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ=="
-    },
     "google-spreadsheet": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/google-spreadsheet/-/google-spreadsheet-5.2.0.tgz",
@@ -11763,9 +11809,9 @@
       "dev": true
     },
     "hyperformula": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.2.0.tgz",
-      "integrity": "sha512-2vzQKKVMDPLsubZJb0JJWT/DhrkgIjsWj40Z9BIUVT6Jkl/YM5VtkLOP3agCieqW9HuqnXlWc+Vi+7XzQuC1Nw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.3.0.tgz",
+      "integrity": "sha512-Mkc7AxP9WQDM4xHo1/XpAwzcpMLkwMand4HO9rfRzP502TBzoR1Z96zoCzRrwXodLSVyh+MD7FvzRVALDxmRFQ==",
       "requires": {
         "chevrotain": "^6.5.0",
         "tiny-emitter": "^2.1.0"
@@ -12992,17 +13038,17 @@
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
     },
     "node-abi": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "version": "3.93.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.93.0.tgz",
+      "integrity": "sha512-Cu6yUpX5Iavugm8BeX7c0wgU9CvOqfd1yM6A1d2q2ZMjym7GjpASv2GdRcTq3Fx+Sb5OgBkEEpw4VnAbY6Y5RA==",
       "requires": {
         "semver": "^7.3.5"
       },
       "dependencies": {
         "semver": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-          "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="
+          "version": "7.8.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+          "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="
         }
       }
     },
@@ -13482,9 +13528,9 @@
           }
         },
         "tar-fs": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-          "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+          "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
           "requires": {
             "chownr": "^1.1.1",
             "mkdirp-classic": "^0.5.2",
@@ -14279,9 +14325,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-          "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+          "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
           "requires": {
             "balanced-match": "^1.0.0"
           }
@@ -14343,9 +14389,9 @@
           }
         },
         "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "version": "16.2.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+          "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
           "requires": {
             "cliui": "^7.0.2",
             "escalade": "^3.1.1",
@@ -14369,9 +14415,9 @@
       "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw=="
     },
     "ua-parser-js": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.9.tgz",
-      "integrity": "sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.10.tgz",
+      "integrity": "sha512-t+3Ktbq0Ies2vaSezfOaWiolH4OigQIO1dk+1xDpOydB1COVPocVYOrEV5rqZ0kFY9XYG1v9LutCyMgYBpABcw==",
       "requires": {
         "detect-europe-js": "^0.1.2",
         "is-standalone-pwa": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/daniel-hauser/moneyman#readme",
   "dependencies": {
-    "@actual-app/api": "^26.5.0",
+    "@actual-app/api": "^26.6.0",
     "@mswjs/interceptors": "^0.41.8",
     "@telegraf/entity": "^0.7.0",
     "async": "^3.2.6",


### PR DESCRIPTION
## Version bump

Bumps the Actual Budget API client `@actual-app/api` from `^26.5.0` to the latest **`^26.6.0`**.

- `package.json`: single-line bump `^26.5.0` → `^26.6.0`
- `package-lock.json`: regenerated (transitive dependency updates in the Actual tree)

## Why to `release`

The `@actual-app/api` dependency lives on the fork's `release` branch (Actual Budget support is a fork customization tracked here, not on `main`). This PR targets `release` directly so the bump lands only after review — keeping with the "nothing reaches `release` without a reviewed PR" flow.

## Notes

The bump was not built/tested locally (this environment runs Node 22, while the project requires Node ≥24). CI (`pr-build`) validates the build and image on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017hhe6aRosGZ39KPECL7gcs)_